### PR TITLE
Inclusion of fields request in getIdentity.

### DIFF
--- a/facebook_server.js
+++ b/facebook_server.js
@@ -2,22 +2,22 @@ Facebook = {};
 
 var querystring = Npm.require('querystring');
 
-
 OAuth.registerService('facebook', 2, null, function(query) {
 
   var response = getTokenResponse(query);
   var accessToken = response.accessToken;
-  var identity = getIdentity(accessToken);
+
+  // include all fields from facebook
+  // http://developers.facebook.com/docs/reference/login/public-profile-and-friend-list/
+  var whitelisted = ['id', 'email', 'name', 'first_name',
+      'last_name', 'link', 'gender', 'locale', 'age_range'];
+  
+  var identity = getIdentity(accessToken, whitelisted);
 
   var serviceData = {
     accessToken: accessToken,
     expiresAt: (+new Date) + (1000 * response.expiresIn)
   };
-
-  // include all fields from facebook
-  // http://developers.facebook.com/docs/reference/login/public-profile-and-friend-list/
-  var whitelisted = ['id', 'email', 'name', 'first_name',
-      'last_name', 'link', 'username', 'gender', 'locale', 'age_range'];
 
   var fields = _.pick(identity, whitelisted);
   _.extend(serviceData, fields);
@@ -100,10 +100,14 @@ var getTokenResponse = function (query) {
   };
 };
 
-var getIdentity = function (accessToken) {
+var getIdentity = function (accessToken, fields) {
   try {
-    return HTTP.get("https://graph.facebook.com/me", {
-      params: {access_token: accessToken}}).data;
+    return HTTP.get("https://graph.facebook.com/v2.4/me", {
+      params: {
+        access_token: accessToken,
+        fields: fields
+      }
+    }).data;
   } catch (err) {
     throw _.extend(new Error("Failed to fetch identity from Facebook. " + err.message),
                    {response: err.response});


### PR DESCRIPTION
Inclusion of the whitelisted `fields` in the `getIdentity` request function, as seen on
https://github.com/meteor/meteor/commit/76f46f24578bc9a3a09a99f6f702f68445d85a4a.
Exclusion of the `username` field due to its deprecation on versions v2.0 and higher of Graph API